### PR TITLE
Potential fix for code scanning alert no. 7: Query built by concatenation with a possibly-untrusted string

### DIFF
--- a/LoginInseguro.java
+++ b/LoginInseguro.java
@@ -15,9 +15,12 @@ public class LoginInseguro {
         try (Connection conn = DriverManager.getConnection("jdbc:sqlite:usuarios.db");
              Statement stmt = conn.createStatement()) {
 
-            // 🔴 Vulnerabilidade: Concatenação direta na query SQL
-            String query = "SELECT * FROM usuarios WHERE nome = '" + nome + "' AND senha = '" + senha + "'";
-            ResultSet rs = stmt.executeQuery(query);
+            // ✅ Usar PreparedStatement para evitar SQL Injection
+            String query = "SELECT * FROM usuarios WHERE nome = ? AND senha = ?";
+            PreparedStatement pstmt = conn.prepareStatement(query);
+            pstmt.setString(1, nome);
+            pstmt.setString(2, senha);
+            ResultSet rs = pstmt.executeQuery();
 
             if (rs.next()) {
                 System.out.println("Login bem-sucedido!");


### PR DESCRIPTION
Potential fix for [https://github.com/grb-mminamoto/SI1/security/code-scanning/7](https://github.com/grb-mminamoto/SI1/security/code-scanning/7)

To fix the problem, we should use a prepared statement instead of directly concatenating user inputs into the SQL query. Prepared statements allow us to define the SQL query with placeholders for the parameters and then safely set the parameter values. This approach prevents SQL injection attacks by ensuring that user inputs are treated as data rather than executable code.

The best way to fix the problem without changing existing functionality is to replace the concatenated query with a prepared statement. We will define the SQL query with placeholders (`?`) for the `nome` and `senha` parameters and then use the `setString` method to set the values of these parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
